### PR TITLE
Use FabricJS v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,6 @@
 # HTML5 Drawing Tool
 
-This is HTML5 Drawing Tool, built with [Brunch](http://brunch.io) and uses [Fabric](http://fabricjs.com).
-[View the demo](http://concord-consortium.github.io/drawing-tool/examples/)
-
-## Getting started
-* Install (if you don't have them):
-    * [Node.js](http://nodejs.org): `brew install node` on OS X
-    * [Brunch](http://brunch.io): `npm install -g brunch`
-    * [Bower](http://bower.io): `npm install -g bower`
-    * Brunch plugins and Bower dependencies: `npm install & bower install`.
-* Run:
-    * `brunch watch --server` — watches the project with continuous rebuild. This will also launch HTTP server with [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history).
-    * `brunch build --production` — builds minified project for production
-* Learn:
-    * `public/` dir is fully auto-generated and served by HTTP server.  Write your code in `app/` dir.
-    * Place static files you want to be copied from `app/assets/` to `public/`.
-    * [Brunch site](http://brunch.io), [Chaplin site](http://chaplinjs.org)
-
-
-## Development
-
-* Run `brunch watch --server`.
-* Open [http://localhost:3333/examples/](http://localhost:3333/examples/).
-* Code!
-* Before you commit you should run `brunch build -e dist` to update `dist` directory and add it to git index.
-
-## Deploying to Github Pages
-
-Use `push-gh-pages.sh` script. It (re)generates `public` dir using `bower build -e production`, updates `gh-pages` branch
-(using `public` content) and pushes changes to Github.
-
-Note that you may deploy uncommited changes, as this script uses current working directory state.
-
-## Updating Bower package.
-
-http://bower.io/search/?q=drawing-tool
-
-* Remember that Bower expects [semver](http://semver.org/) tags.
-* Update version in `package.json` and `bower.json`.
-* Make sure that `dist` folder is up to date! Run `brunch build -e dist` to double-check that.
-* Commit all changes and then run: `git tag -a v1.2.3 -m "Release version 1.2.3"`.
-* Push changes remembering about `--tags` option: `git push origin master --tags`.
+Demo: http://concord-consortium.github.io/drawing-tool/examples/
 
 ## Dependencies
 
@@ -51,7 +11,39 @@ http://bower.io/search/?q=drawing-tool
 
 All of these libraries are concatenated together in `dist/vendor.js` file.
 
-## Undo / redo feature
+## Development
+* Install (if you don't have them):
+    * [Node.js](http://nodejs.org): `brew install node` on OS X
+    * [Brunch](http://brunch.io): `npm install -g brunch`
+    * [Bower](http://bower.io): `npm install -g bower`
+    * Brunch plugins and Bower dependencies: `npm install & bower install`.
+* Run:
+    * `brunch watch --server` — watches the project with continuous rebuild. This will also launch HTTP server with [pushState](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history).
+    * Open [http://localhost:3333/examples/](http://localhost:3333/examples/).
+    * Code!
+    * Before you commit, run `brunch build -e dist` to update `dist` directory and add it to git index.
+* Learn:
+    * `public/` dir is fully auto-generated and served by HTTP server.  Write your code in `app/` dir.
+    * Place static files you want to be copied from `app/assets/` to `public/`.
+
+### Deploying to Github Pages
+
+Use `push-gh-pages.sh` script. It (re)generates `public` dir using `bower build -e production`, updates `gh-pages` branch
+(using `public` content) and pushes changes to Github.
+
+Note that you may deploy uncommited changes, as this script uses current working directory state.
+
+### Updating Bower package.
+
+http://bower.io/search/?q=drawing-tool
+
+* Remember that Bower expects [semver](http://semver.org/) tags.
+* Update version in `package.json` and `bower.json`.
+* Make sure that `dist` folder is up to date! Run `brunch build -e dist` to double-check that.
+* Commit all changes and then run: `git tag -a v1.2.3 -m "Release version 1.2.3"`.
+* Push changes remembering about `--tags` option: `git push origin master --tags`.
+
+### Undo / redo feature
 
 If you are planning to add new feature that will be exposed in UI or via main API, you should consider whether
 this action should be saved in history (so undo and redo is possible) or not.
@@ -74,3 +66,7 @@ However state of the drawing tool itself is not tracked, so e.g. following event
 If an action is async and callback can be provided, callback should be invoked **after** history is updated
 (see `DrawingTool.setBackgroundImage`). It gives us more flexibility, as the client code can reset history
 after action is complete so user won't be able to undo it (sometimes it is useful).
+
+### JSON state converter
+
+Drawing Tool state can be serialized to JSON. If you're introducing non-backward compatible change, update version in `DrawingTool#save` method and add approperiate conversion to `convert-state.js`.

--- a/app/assets/examples/index.html
+++ b/app/assets/examples/index.html
@@ -32,9 +32,6 @@
   <script src="../drawing-tool.js"></script>
   <script>
     var drawingTool = new DrawingTool("#drawing-tool", {
-      proxy: function (url) {
-        return 'https://cors-anywhere.herokuapp.com/' + url;
-      },
       stamps: {
         'Molecules': [
           'https://interactions-resources.concord.org/stamps/simple-atom-ng.svg',

--- a/app/assets/examples/index.html
+++ b/app/assets/examples/index.html
@@ -32,19 +32,37 @@
   <script src="../drawing-tool.js"></script>
   <script>
     var drawingTool = new DrawingTool("#drawing-tool", {
+      proxy: function (url) {
+        return 'https://cors-anywhere.herokuapp.com/' + url;
+      },
       stamps: {
         'Molecules': [
-          'http://resources.interactions.concord.org/stamps/simple-atom-ng.svg',
-          'http://resources.interactions.concord.org/stamps/diatomic-ng.svg',
-          'http://resources.interactions.concord.org/stamps/triatomic-ng.svg',
-          'http://resources.interactions.concord.org/stamps/positive-charge-symbol.svg',
-          'http://resources.interactions.concord.org/stamps/negative-charge-symbol.svg',
-          'http://resources.interactions.concord.org/stamps/positive-atom-ng.svg',
-          'http://resources.interactions.concord.org/stamps/negative-atom-ng.svg',
-          'http://resources.interactions.concord.org/stamps/slow-particle-ng.svg',
-          'http://resources.interactions.concord.org/stamps/medium-particle-ng.svg',
-          'http://resources.interactions.concord.org/stamps/fast-particle-ng.svg',
-          'http://resources.interactions.concord.org/stamps/low-density-particles.svg'
+          'https://interactions-resources.concord.org/stamps/simple-atom-ng.svg',
+          'https://interactions-resources.concord.org/stamps/diatomic-ng.svg',
+          'https://interactions-resources.concord.org/stamps/diatomic-red-ng.svg',
+          'https://interactions-resources.concord.org/stamps/triatomic-ng.svg',
+          'https://interactions-resources.concord.org/stamps/positive-charge-symbol.svg',
+          'https://interactions-resources.concord.org/stamps/negative-charge-symbol.svg',
+          'https://interactions-resources.concord.org/stamps/positive-atom-ng.svg',
+          'https://interactions-resources.concord.org/stamps/negative-atom-ng.svg',
+          'https://interactions-resources.concord.org/stamps/slow-particle-ng.svg',
+          'https://interactions-resources.concord.org/stamps/medium-particle-ng.svg',
+          'https://interactions-resources.concord.org/stamps/fast-particle-ng.svg',
+          'https://interactions-resources.concord.org/stamps/low-density-particles.svg'
+        ],
+        'Molecules (gradient)': [
+          'https://interactions-resources.concord.org/stamps/simple-atom.svg',
+          'https://interactions-resources.concord.org/stamps/diatomic.svg',
+          'https://interactions-resources.concord.org/stamps/diatomic-red.svg',
+          'https://interactions-resources.concord.org/stamps/triatomic.svg',
+          'https://interactions-resources.concord.org/stamps/positive-charge-symbol.svg',
+          'https://interactions-resources.concord.org/stamps/negative-charge-symbol.svg',
+          'https://interactions-resources.concord.org/stamps/positive-atom.svg',
+          'https://interactions-resources.concord.org/stamps/negative-atom.svg',
+          'https://interactions-resources.concord.org/stamps/slow-particle.svg',
+          'https://interactions-resources.concord.org/stamps/medium-particle.svg',
+          'https://interactions-resources.concord.org/stamps/fast-particle.svg',
+          'https://interactions-resources.concord.org/stamps/low-density-particles.svg'
         ]
       },
       parseSVG: true

--- a/app/assets/examples/two-tools.html
+++ b/app/assets/examples/two-tools.html
@@ -25,9 +25,6 @@
     var drawingTool = new DrawingTool("#drawing-tool-1", {
       width: 500,
       height: 600,
-      proxy: function (url) {
-        return 'https://cors-anywhere.herokuapp.com/' + url;
-      },
       stamps: {
         'Molecules': [
           'https://interactions-resources.concord.org/stamps/simple-atom.svg',

--- a/app/assets/examples/two-tools.html
+++ b/app/assets/examples/two-tools.html
@@ -25,22 +25,28 @@
     var drawingTool = new DrawingTool("#drawing-tool-1", {
       width: 500,
       height: 600,
+      proxy: function (url) {
+        return 'https://cors-anywhere.herokuapp.com/' + url;
+      },
       stamps: {
         'Molecules': [
-          'http://resources.interactions.concord.org/stamps/simple-atom-ng.svg',
-          'http://resources.interactions.concord.org/stamps/diatomic-ng.svg',
-          'http://resources.interactions.concord.org/stamps/triatomic-ng.svg'
+          'https://interactions-resources.concord.org/stamps/simple-atom.svg',
+          'https://interactions-resources.concord.org/stamps/diatomic.svg',
+          'https://interactions-resources.concord.org/stamps/triatomic.svg'
         ]
       }
     });
     var drawingTool2 = new DrawingTool("#drawing-tool-2", {
       width: 500,
       height: 600,
+      proxy: function (url) {
+        return 'https://cors-anywhere.herokuapp.com/' + url;
+      },
       stamps: {
         'Molecules': [
-          'http://resources.interactions.concord.org/stamps/simple-atom-ng.svg',
-          'http://resources.interactions.concord.org/stamps/diatomic-ng.svg',
-          'http://resources.interactions.concord.org/stamps/triatomic-ng.svg'
+          'https://interactions-resources.concord.org/stamps/simple-atom.svg',
+          'https://interactions-resources.concord.org/stamps/diatomic.svg',
+          'https://interactions-resources.concord.org/stamps/triatomic.svg'
         ]
       }
     });

--- a/app/scripts/convert-state.js
+++ b/app/scripts/convert-state.js
@@ -1,0 +1,49 @@
+// Converts drawing tool state JSON created using old version to the most recent one.
+// Ensures that Drawing Tool is backward compatible.
+
+var stateConverter = {
+  0: convertVer0toVer1
+  // In the future (in case of need):
+  // 2: convertVer1toVer2
+  // etc.
+};
+
+// Version 0 is using FabricJS 1.4.11
+// Version 1 is using FabricJS 1.5.0
+// New FabricJS version serializes paths in a different way, see:
+// https://github.com/kangax/fabric.js/issues/2139
+function convertVer0toVer1(state) {
+  state.canvas.objects.forEach(function (obj) {
+    if (obj.type === 'path') {
+      obj.pathOffset.x = obj.left;
+      obj.pathOffset.y = obj.top;
+      var offsetX = obj.left - obj.width * 0.5;
+      var offsetY = obj.top - obj.height * 0.5;
+      var path = obj.path;
+      for (var i = 0; i < path.length; i++) {
+        var def = path[i];
+        for (var j = 1; j < def.length; j++) {
+          if (j % 2 === 1) {
+            def[j] += offsetX;
+          } else {
+            def[j] += offsetY;
+          }
+        }
+      }
+    }
+  });
+  state.version = 1;
+  return state;
+}
+
+function convertState(state) {
+  if (typeof state.version === 'undefined') {
+    state.version = 0;
+  }
+  while (stateConverter[state.version]) {
+    state = stateConverter[state.version](state);
+  }
+  return state;
+}
+
+module.exports = convertState;

--- a/app/scripts/drawing-tool.js
+++ b/app/scripts/drawing-tool.js
@@ -8,6 +8,7 @@ var DeleteTool        = require('scripts/tools/delete-tool');
 var CloneTool         = require('scripts/tools/clone-tool');
 var UIManager         = require('scripts/ui/ui-manager');
 var UndoRedo          = require('scripts/undo-redo');
+var convertState      = require('scripts/convert-state');
 var rescale2resize    = require('scripts/fabric-extensions/rescale-2-resize');
 var multitouchSupport = require('scripts/fabric-extensions/multi-touch-support');
 
@@ -151,6 +152,7 @@ DrawingTool.prototype.save = function () {
     selectionCleared = true;
   }
   var result = JSON.stringify({
+    version: 1,
     dt: {
       // Drawing Tool specific options.
       width: this.canvas.getWidth(),
@@ -184,6 +186,8 @@ DrawingTool.prototype.load = function (jsonString, callback, noHistoryUpdate) {
   }
 
   var state = JSON.parse(jsonString);
+  // Support JSONs saved by older Drawing Tool versions.
+  state = convertState(state);
 
   // Process Drawing Tool specific options.
   var dtState = state.dt;

--- a/app/scripts/fabric-extensions/rescale-2-resize.js
+++ b/app/scripts/fabric-extensions/rescale-2-resize.js
@@ -40,20 +40,15 @@ var duringResize = {
     this.line(s);
   },
   path: function (s) {
+    var offsetX = s.pathOffset.x;
+    var offsetY = s.pathOffset.y;
     for (var i = 0; i < s.path.length; i++) {
-      s.path[i][1] *= s.scaleX;
-      s.path[i][2] *= s.scaleY;
-      s.path[i][3] *= s.scaleX;
-      s.path[i][4] *= s.scaleY;
+      s.path[i][1] = (s.path[i][1] - offsetX) * s.scaleX + offsetX;
+      s.path[i][2] = (s.path[i][2] - offsetY) * s.scaleY + offsetY;
+      s.path[i][3] = (s.path[i][3] - offsetX) * s.scaleX + offsetX;
+      s.path[i][4] = (s.path[i][4] - offsetY) * s.scaleY + offsetY;
     }
-    // We have two options to adjust width/height:
-    // 1) this makes inaccurate bounding box dimensions but
-    //    eliminates "floating" or weird behavior at edges
     basicWidthHeightTransform(s);
-    // 2) this approach "floats" and has strange bugs but
-    //    generates accurate bounding boxes
-    // s.width = s.width * s.scaleX;
-    // s.height = s.height * s.scaleY;
   }
 };
 

--- a/bower.json
+++ b/bower.json
@@ -13,9 +13,9 @@
     "package.json"
   ],
   "dependencies": {
-    "fabric": "1.4.11",
-    "hammerjs": "2.0.0",
-    "jquery": "2.1.1",
+    "fabric": "1.5.0",
+    "hammerjs": "2.0.4",
+    "jquery": "2.1.3",
     "eventemitter2": "0.4.14"
   },
   "overrides": {

--- a/dist/drawing-tool.js
+++ b/dist/drawing-tool.js
@@ -1372,20 +1372,15 @@ var duringResize = {
     this.line(s);
   },
   path: function (s) {
+    var offsetX = s.pathOffset.x;
+    var offsetY = s.pathOffset.y;
     for (var i = 0; i < s.path.length; i++) {
-      s.path[i][1] *= s.scaleX;
-      s.path[i][2] *= s.scaleY;
-      s.path[i][3] *= s.scaleX;
-      s.path[i][4] *= s.scaleY;
+      s.path[i][1] = (s.path[i][1] - offsetX) * s.scaleX + offsetX;
+      s.path[i][2] = (s.path[i][2] - offsetY) * s.scaleY + offsetY;
+      s.path[i][3] = (s.path[i][3] - offsetX) * s.scaleX + offsetX;
+      s.path[i][4] = (s.path[i][4] - offsetY) * s.scaleY + offsetY;
     }
-    // We have two options to adjust width/height:
-    // 1) this makes inaccurate bounding box dimensions but
-    //    eliminates "floating" or weird behavior at edges
     basicWidthHeightTransform(s);
-    // 2) this approach "floats" and has strange bugs but
-    //    generates accurate bounding boxes
-    // s.width = s.width * s.scaleX;
-    // s.height = s.height * s.scaleY;
   }
 };
 

--- a/dist/drawing-tool.js
+++ b/dist/drawing-tool.js
@@ -90,6 +90,60 @@
   globals.require.list = list;
   globals.require.brunch = true;
 })();
+require.register("scripts/convert-state", function(exports, require, module) {
+var $ = jQuery;
+// Converts drawing tool state JSON created using old version to the most recent one.
+// Ensures that Drawing Tool is backward compatible.
+
+var stateConverter = {
+  0: convertVer0toVer1
+  // In the future (in case of need):
+  // 2: convertVer1toVer2
+  // etc.
+};
+
+// Version 0 is using FabricJS 1.4.11
+// Version 1 is using FabricJS 1.5.0
+// New FabricJS version serializes paths in a different way, see:
+// https://github.com/kangax/fabric.js/issues/2139
+function convertVer0toVer1(state) {
+  state.canvas.objects.forEach(function (obj) {
+    if (obj.type === 'path') {
+      obj.pathOffset.x = obj.left;
+      obj.pathOffset.y = obj.top;
+      var offsetX = obj.left - obj.width * 0.5;
+      var offsetY = obj.top - obj.height * 0.5;
+      var path = obj.path;
+      for (var i = 0; i < path.length; i++) {
+        var def = path[i];
+        for (var j = 1; j < def.length; j++) {
+          if (j % 2 === 1) {
+            def[j] += offsetX;
+          } else {
+            def[j] += offsetY;
+          }
+        }
+      }
+    }
+  });
+  state.version = 1;
+  return state;
+}
+
+function convertState(state) {
+  if (typeof state.version === 'undefined') {
+    state.version = 0;
+  }
+  while (stateConverter[state.version]) {
+    state = stateConverter[state.version](state);
+  }
+  return state;
+}
+
+module.exports = convertState;
+
+});
+
 require.register("scripts/drawing-tool", function(exports, require, module) {
 var $ = jQuery;
 var SelectionTool     = require('scripts/tools/select-tool');
@@ -102,6 +156,7 @@ var DeleteTool        = require('scripts/tools/delete-tool');
 var CloneTool         = require('scripts/tools/clone-tool');
 var UIManager         = require('scripts/ui/ui-manager');
 var UndoRedo          = require('scripts/undo-redo');
+var convertState      = require('scripts/convert-state');
 var rescale2resize    = require('scripts/fabric-extensions/rescale-2-resize');
 var multitouchSupport = require('scripts/fabric-extensions/multi-touch-support');
 
@@ -245,6 +300,7 @@ DrawingTool.prototype.save = function () {
     selectionCleared = true;
   }
   var result = JSON.stringify({
+    version: 1,
     dt: {
       // Drawing Tool specific options.
       width: this.canvas.getWidth(),
@@ -278,6 +334,8 @@ DrawingTool.prototype.load = function (jsonString, callback, noHistoryUpdate) {
   }
 
   var state = JSON.parse(jsonString);
+  // Support JSONs saved by older Drawing Tool versions.
+  state = convertState(state);
 
   // Process Drawing Tool specific options.
   var dtState = state.dt;


### PR DESCRIPTION
1. https://www.pivotaltracker.com/story/show/90693952 if fixed now.

2. New FabricJS introduces some non-backward compatible changes related to paths (free hand draw tool). Resizing of paths has been updated to fix it.

3. New JSON format is incompatible with the old one (paths), so I've implement versioning of JSON state and automatic conversion from old JSON format to new one. The same pattern can be used in the future in case of need.

4. New FabricJS fixes SVG rendering, so finally we can use stamps with gradient and we don't have to provide weird tweaks to SVG images. This has a bad side effect though - if user loads old JSON with old stamps, they will look a bit incorrect. That could be theoretically handled in conversion script mentioned above, but I don't think it's worth it. Stamps will be visible, still meaningful, but some of their elements will be shifted a bit. If you try to add some stamps from "Molecules" category [on this page](http://concord-consortium.github.io/drawing-tool/examples/), you will see exactly what user is going to see if he loads his old image. "Molecules (gradient)" stamps don't have any tweaks related to old FabricJS bugs, so we should use them once this branch is merged.

This branch is deployed to:
http://concord-consortium.github.io/drawing-tool/examples/
so you can test it and take a look at stamps.