### PR TITLE
Fix bug in delete tool keydown event listener [#178986947]

### DIFF
--- a/app/scripts/tools/delete-tool.js
+++ b/app/scripts/tools/delete-tool.js
@@ -10,11 +10,13 @@ function DeleteTool(name, drawTool) {
 
   this.singleUse = true;
 
-  // Delete the selected object(s) with the backspace key.
+  // Delete the selected object(s) with the backspace and delete key when not using the text tool
   this.master.$element.on('keydown', function(e) {
-    if (e.keyCode === 8) {
-      this.use();
-      e.preventDefault();
+    if ((e.keyCode === 8) || (e.keyCode === 46)) {
+      if (this.master.currentTool !== this.master.tools.text) {
+        this.use();
+        e.preventDefault();
+      }
     }
   }.bind(this));
 }


### PR DESCRIPTION
Prior to this fix pressing the backspace while entering text in the text tool would cause the text element to be deleted.

This fix prevents that and also adds the ability to delete with the delete key.