### PR TITLE
Hardcoded fill and stroke svg contents

### DIFF
--- a/app/scripts/ui/fill-button.js
+++ b/app/scripts/ui/fill-button.js
@@ -2,9 +2,38 @@ var $           = require('jquery');
 var inherit     = require('../inherit');
 var BasicButton = require('./basic-button');
 
-var fillIconParts = require('../../assets/color-fill-icon.svg').default.split(",");
-var dataUriPrefix = fillIconParts[0];
-var fillIconSVG = window.atob(fillIconParts[1]);
+// The following require works in the stand-alone mode but fails when integrated in question-interactives
+// as the file is not found during the build process.  Instead of copying the file its contents are put
+// here as the code would break anyway if the contents were updated as the setColor method does a search
+// and replace on the svg content.
+// var fillIconParts = require('../../assets/color-fill-icon.svg').default.split(",");
+var fillIconSVG = [
+  '<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36">',
+  '    <defs>',
+  '        <filter id="5d93qer36a" color-interpolation-filters="auto">',
+  '            <feColorMatrix in="SourceGraphic" values="0 0 0 0 0.015686 0 0 0 0 0.505882 0 0 0 0 0.627451 0 0 0 1.000000 0"/>',
+  '        </filter>',
+  '    </defs>',
+  '    <g fill="none" fill-rule="evenodd">',
+  '        <g>',
+  '            <g>',
+  '                <path d="M0 0H36V36H0z" transform="translate(-2177.000000, -942.000000) translate(2177.000000, 942.000000)"/>',
+  '                <g>',
+  '                    <path fill-rule="nonzero" d="M0 17.999H26V22.999H0z" transform="translate(-2177.000000, -942.000000) translate(2177.000000, 942.000000) translate(5.000000, 7.000575)"/>',
+  '                    <path id="color_fill_bar" fill="#545454" d="M0 18H26V23H0z" transform="translate(-2131.000000, -942.000000) translate(2131.000000, 942.000000) translate(5.000000, 7.000000)"/>',
+  '                    <path id="color_fill_outline" fill="#979797" d="M26 18v5H0v-5h26zm-.5.5H.5v4h25v-4z" transform="translate(-2177.000000, -942.000000) translate(2177.000000, 942.000000) translate(5.000000, 7.000575)"/>',
+  '                    <g filter="url(#5d93qer36a)" transform="translate(-2177.000000, -942.000000) translate(2177.000000, 942.000000) translate(5.000000, 7.000575)">',
+  '                        <g>',
+  '                            <path fill="#0481A0" d="M7.01 4.07l4.427 4.427H2.583L7.01 4.07zm6.717 4.243L5.67.257c-.34-.342-.893-.342-1.235-.001-.344.34-.344.896-.002 1.238l1.34 1.34-5.48 5.479c-.39.39-.39 1.024 0 1.414l6.01 6.01c.196.195.452.293.709.293.255 0 .511-.098.707-.293l6.01-6.01c.39-.39.39-1.023 0-1.414zM17.98 14.23c0 1.035-.839 1.875-1.874 1.875-1.035 0-1.874-.84-1.874-1.874 0-1.521 1.891-3.21 1.891-3.21s1.857 1.666 1.857 3.21" transform="translate(4.000300, 0.000000)"/>',
+  '                        </g>',
+  '                    </g>',
+  '                </g>',
+  '            </g>',
+  '        </g>',
+  '    </g>',
+  '</svg>'
+].join("");
+
 function FillButton(options, ui, drawingTool) {
   BasicButton.call(this, options, ui, drawingTool);
 }
@@ -19,7 +48,7 @@ FillButton.prototype.setColor = function(color) {
   var newSVG = fillIconSVG
     .replace('id="color_fill_bar" fill="#545454"', 'id="color_fill_bar" fill="' + color + '"')
     .replace('id="color_fill_outline" fill="#979797"', 'id="color_fill_bar" fill="' + outlineColor + '"')
-  var newDataUri = [dataUriPrefix, window.btoa(newSVG)].join(",");
+  var newDataUri = ["data:image/svg+xml;base64", window.btoa(newSVG)].join(",");
   var img = this.$element.find("img");
   img.attr('src', newDataUri)
 };

--- a/app/scripts/ui/stroke-button.js
+++ b/app/scripts/ui/stroke-button.js
@@ -2,9 +2,27 @@ var $           = require('jquery');
 var inherit     = require('../inherit');
 var BasicButton = require('./basic-button');
 
-var strokeIconParts = require('../../assets/color-stroke-icon.svg').default.split(",");
-var dataUriPrefix = strokeIconParts[0];
-var strokeIconSVG = window.atob(strokeIconParts[1]);
+// The following require works in the stand-alone mode but fails when integrated in question-interactives
+// as the file is not found during the build process.  Instead of copying the file its contents are put
+// here as the code would break anyway if the contents were updated as the setColor method does a search
+// and replace on the svg content.
+// var strokeIconParts = require('../../assets/color-stroke-icon.svg').default.split(",");
+var strokeIconSVG = [
+  '<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36">',
+  '    <g fill="none" fill-rule="evenodd">',
+  '        <g>',
+  '            <g>',
+  '                <path d="M0 0H36V36H0z" transform="translate(-2131.000000, -942.000000) translate(2131.000000, 942.000000)"/>',
+  '                <g>',
+  '                    <path id="color_stroke_bar" fill="#545454" d="M0 18H26V23H0z" transform="translate(-2131.000000, -942.000000) translate(2131.000000, 942.000000) translate(5.000000, 7.000000)"/>',
+  '                    <path id="color_stroke_outline" fill="#545454" d="M26 18v5H0v-5h26zm-.5.5H.5v4h25v-4z" transform="translate(-2131.000000, -942.000000) translate(2131.000000, 942.000000) translate(5.000000, 7.000000)"/>',
+  '                    <path fill="#0481A0" d="M7.91 13.248h1.478v1.135l-1.987.353-.958-.972.347-2.016h1.12v1.5zM9.02 10.62c-.17-.17-.17-.446 0-.618l4.745-4.812c.17-.172.44-.172.61 0 .17.171.17.446 0 .618l-4.745 4.812c-.169.172-.44.172-.61 0zm4.933-7.502l-8.092 8.205-.652 3.798c-.09.513.35.956.856.869l3.744-.665L17.9 7.118c.145-.148.145-.385 0-.532l-3.42-3.47c-.148-.146-.382-.146-.527 0zm6.585 1.322l-1.42 1.441c-.146.145-.38.145-.524 0l-3.42-3.47c-.146-.147-.146-.385 0-.53l1.42-1.441c.576-.585 1.513-.585 2.091 0l1.853 1.878c.58.584.58 1.533 0 2.122z" transform="translate(-2131.000000, -942.000000) translate(2131.000000, 942.000000) translate(5.000000, 7.000000)"/>',
+  '                </g>',
+  '            </g>',
+  '        </g>',
+  '    </g>',
+  '</svg>'
+].join("");
 
 function StrokeButton(options, ui, drawingTool, extraClasses) {
   BasicButton.call(this, options, ui, drawingTool, extraClasses);
@@ -20,7 +38,7 @@ StrokeButton.prototype.setColor = function(color) {
   var newSVG = strokeIconSVG
     .replace('id="color_stroke_bar" fill="#545454"', 'id="color_stroke_bar" fill="' + color + '"')
     .replace('id="color_stroke_outline" fill="#545454"', 'id="color_stroke_bar" fill="' + outlineColor + '"')
-  var newDataUri = [dataUriPrefix, window.btoa(newSVG)].join(",");
+  var newDataUri = ["data:image/svg+xml;base64", window.btoa(newSVG)].join(",");
   var img = this.$element.find("img");
   img.attr('src', newDataUri)
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "drawing-tool",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "drawing-tool",
   "description": "HTML5 Drawing Tool",
   "author": "",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "bugs": {
     "url": "https://github.com/concord-consortium/drawing-tool/issues"
   },


### PR DESCRIPTION
This gets around a build issue in question-interactives which processes svg files using @svgr/webpack.