### PR TITLE
Fix annotation box selection, disable pixel perfect selection

### DIFF
--- a/app/scripts/drawing-tool.js
+++ b/app/scripts/drawing-tool.js
@@ -743,17 +743,6 @@ DrawingTool.prototype._initDOM = function () {
 
 DrawingTool.prototype._initFabricJS = function () {
   this.canvas = new fabric.Canvas(this.$canvas[0], { preserveObjectStacking: true });
-  // Target find would be more tolerant on touch devices.
-  // Also SVG images added to canvas will taint it in some browsers, no matter whether
-  // it's coming from the same or another domain (e.g. Safari, IE). In such case, we
-  // have to use bounding box target find, as per pixel tries to read canvas data
-  // (impossible when canvas is tainted).
-  if (fabric.isTouchSupported || !this.options.parseSVG) {
-    this.canvas.perPixelTargetFind = false;
-  } else {
-    this.canvas.perPixelTargetFind = true;
-    this.canvas.targetFindTolerance = 12;
-  }
   this.canvas.setBackgroundColor('#fff');
 };
 

--- a/app/scripts/fabric-extensions/annotations.js
+++ b/app/scripts/fabric-extensions/annotations.js
@@ -326,6 +326,12 @@ module.exports = handleAnnotations;
         fabric.Annotations.set(options.annotationId, this);
       },
 
+      containsPoint: function (point) {
+        var borderRect = fabric.Annotations.calcBorderRect(this);
+        return point.x >= borderRect.left && point.x <= borderRect.left + borderRect.width &&
+               point.y >= borderRect.top && point.y <= borderRect.top + borderRect.height;
+      },
+
       _renderTextCommon: function (ctx, method) {
         this.callSuper('_renderTextCommon', ctx, method);
 

--- a/app/scripts/tools/shape-tools/annotation-tool.js
+++ b/app/scripts/tools/shape-tools/annotation-tool.js
@@ -42,6 +42,16 @@ AnnotationTool.prototype.mouseDown = function (opt) {
     this.editText(target, opt.e);
     return;
   }
+  // If user clicks on the border, find related text object and edit it.
+  if (target && target.type === fabric.AnnotationBorder.prototype.type) {
+    var text = fabric.Annotations.get(
+      target.annotationId,
+      fabric.AnnotationText.prototype.type
+    );
+    this.editText(text, opt.e);
+    return;
+  }
+
   // See #_exitTextEditingOnFirstClick method.
   if (!this.active || opt.e._dt_doNotCreateNewTextObj) return;
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179583551

I've asked on Slack about unifying `perPixelTargetFind` and leaving it always set to `false`:
https://concord-consortium.slack.com/archives/C0M5CM1RA/p1633026302293700
I couldn't make the rest of the fix work otherwise.