### PR TITLE
QI-155: Toolbar keyboard & ARIA accessibility

### DIFF
--- a/app/scripts/jquery-longpress.js
+++ b/app/scripts/jquery-longpress.js
@@ -2,6 +2,14 @@ var $ = require('jquery');
 
 $.fn.longPress = function(listener, timeout) {
   return this.on('mousedown touchstart', function (e) {
+    // Only react to real pointer presses. Keyboard activation runs through
+    // BasicButton#click -> triggerHandler('mousedown'), a synthetic event
+    // with no matching mouseup, so its timer would never be cancelled and
+    // the long-press would always fire (popping the palette open without
+    // moving focus into it). Synthetic jQuery events have no originalEvent.
+    if (!e.originalEvent) {
+      return;
+    }
     var timer;
     timer = setTimeout(function () {
       listener.call(this, e);

--- a/app/scripts/ui/basic-button.js
+++ b/app/scripts/ui/basic-button.js
@@ -39,6 +39,23 @@ function BasicButton(options, ui, drawingTool, extraClasses) {
       .appendTo(this.$element);
   }
 
+  // Keyboard activation. This library deliberately acts on 'mousedown
+  // touchstart' rather than 'click' (see note at the top of this file), so
+  // a native button's Enter/Space click events would be ignored. Trigger
+  // the 'mousedown' handlers directly instead. preventDefault() stops the
+  // browser from also synthesizing a 'click' (and stops Space scrolling).
+  this.$element.on('keydown', function (e) {
+    if (e.keyCode !== 13 /* Enter */ && e.keyCode !== 32 /* Space */) {
+      return;
+    }
+    e.preventDefault();
+    if (this._locked) {
+      return;
+    }
+    this.click();
+    this._hidePaletteAfterKeyboardActivation();
+  }.bind(this));
+
   if (options.onClick) {
     this.$element.on('mousedown touchstart', function (e) {
       if (this._locked) return;
@@ -115,6 +132,17 @@ BasicButton.prototype.click = function () {
   // to #trigger). Use it as otherwise it could interfere with some other
   // handlers listening to 'mousedown' on window (palette auto-hide feature).
   this.$element.triggerHandler('mousedown');
+};
+
+// Popup palettes auto-hide on window 'mousedown', which never fires for
+// keyboard activation, so hide the button's containing palette explicitly.
+// Mirrors the _closeOnClick logic in palette.js: permanent palettes and
+// palettes with hideOnClick=false (stamp categories) stay open.
+BasicButton.prototype._hidePaletteAfterKeyboardActivation = function () {
+  var palette = this.ui.getPalette(this.palette);
+  if (palette && !palette.permanent && palette.hideOnClick && palette.$element.is(':visible')) {
+    palette._hide();
+  }
 };
 
 BasicButton.prototype.setActive = function (v) {

--- a/app/scripts/ui/basic-button.js
+++ b/app/scripts/ui/basic-button.js
@@ -19,7 +19,7 @@ function BasicButton(options, ui, drawingTool, extraClasses) {
 
   this.icon = options.icon && options.icon.default;
 
-  this.$element = $('<div>')
+  this.$element = $('<button type="button">')
     .addClass('dt-btn')
     .addClass(options.classes)
     .addClass(extraClasses)
@@ -29,6 +29,8 @@ function BasicButton(options, ui, drawingTool, extraClasses) {
   if (this.icon) {
     this.$icon = $('<img>')
       .attr('src', this.icon)
+      // Decorative - the button itself provides the accessible name.
+      .attr('alt', '')
       .addClass('icon')
       .appendTo(this.$element);
   } else {

--- a/app/scripts/ui/basic-button.js
+++ b/app/scripts/ui/basic-button.js
@@ -24,6 +24,7 @@ function BasicButton(options, ui, drawingTool, extraClasses) {
     .addClass(options.classes)
     .addClass(extraClasses)
     .attr('title', options.tooltip)
+    .attr('aria-label', options.ariaLabel || options.tooltip)
     .appendTo(ui.getPalette(options.palette).$element);
 
   if (this.icon) {

--- a/app/scripts/ui/basic-button.js
+++ b/app/scripts/ui/basic-button.js
@@ -167,6 +167,9 @@ BasicButton.prototype.setLocked = function (v) {
   } else {
     this.$element.removeClass('dt-locked');
   }
+  // aria-disabled rather than the disabled attribute: locked buttons stay
+  // in the Tab order so keyboard users can still discover them.
+  this.$element.attr('aria-disabled', v ? 'true' : 'false');
   this._locked = v;
 };
 

--- a/app/scripts/ui/basic-button.js
+++ b/app/scripts/ui/basic-button.js
@@ -17,6 +17,11 @@ function BasicButton(options, ui, drawingTool, extraClasses) {
 
   this._locked = false;
 
+  // Buttons that represent an on/off state (tool choice, color, width,
+  // font size, stamp) expose it via aria-pressed. Plain action buttons
+  // (undo, redo, send to back...) must not have aria-pressed at all.
+  this._isToggle = !!(options.activatesTool || options.reflectsTools || options.isToggle);
+
   this.icon = options.icon && options.icon.default;
 
   this.$element = $('<button type="button">')
@@ -26,6 +31,10 @@ function BasicButton(options, ui, drawingTool, extraClasses) {
     .attr('title', options.tooltip)
     .attr('aria-label', options.ariaLabel || options.tooltip)
     .appendTo(ui.getPalette(options.palette).$element);
+
+  if (this._isToggle) {
+    this.$element.attr('aria-pressed', 'false');
+  }
 
   if (this.icon) {
     this.$icon = $('<img>')
@@ -99,11 +108,7 @@ function BasicButton(options, ui, drawingTool, extraClasses) {
     }.bind(this));
 
     drawingTool.on('tool:changed', function (toolName) {
-      if (toolName === options.activatesTool) {
-        this.$element.addClass('dt-active');
-      } else {
-        this.$element.removeClass('dt-active');
-      }
+      this.setActive(toolName === options.activatesTool);
     }.bind(this));
   }
 
@@ -114,7 +119,6 @@ function BasicButton(options, ui, drawingTool, extraClasses) {
         this.setIcon(ui.getButton(toolName));
       } else {
         this.setActive(false);
-        this.$element.removeClass('dt-active');
       }
     }.bind(this));
   }
@@ -151,6 +155,9 @@ BasicButton.prototype.setActive = function (v) {
     this.$element.addClass('dt-active');
   } else {
     this.$element.removeClass('dt-active');
+  }
+  if (this._isToggle) {
+    this.$element.attr('aria-pressed', v ? 'true' : 'false');
   }
 };
 

--- a/app/scripts/ui/color-button.js
+++ b/app/scripts/ui/color-button.js
@@ -15,19 +15,12 @@ function ColorButton(options, ui, drawingTool, extraClasses) {
     };
   }
   options.onClick = callback;
+  options.isToggle = true;
   options.onStateChange = function (state) {
     if (options.type === 'stroke') {
-      if (state.stroke === options.color) {
-        this.$element.addClass('dt-active');
-      } else {
-        this.$element.removeClass('dt-active');
-      }
+      this.setActive(state.stroke === options.color);
     } else {
-      if (state.fill === options.color) {
-        this.$element.addClass('dt-active');
-      } else {
-        this.$element.removeClass('dt-active');
-      }
+      this.setActive(state.fill === options.color);
     }
   };
   BasicButton.call(this, options, ui, drawingTool, extraClasses);

--- a/app/scripts/ui/generate-stamps.js
+++ b/app/scripts/ui/generate-stamps.js
@@ -31,7 +31,8 @@ function generateStamps(uiDefinition, stampsDefition) {
     name: 'stampCategories',
     anchor: 'stamp',
     vertical: true,
-    hideOnClick: false
+    hideOnClick: false,
+    label: 'Stamp categories'
   });
 
   // Generate separate palettes with stamp buttons for each category.
@@ -56,6 +57,7 @@ function generateStamps(uiDefinition, stampsDefition) {
       anchor: categoryBtnName,
       topOffset: -1.5,
       leftOffset: -1.5,
+      label: category + ' stamps'
     };
     uiDefinition.palettes.push(categoryPalette);
 

--- a/app/scripts/ui/generate-stamps.js
+++ b/app/scripts/ui/generate-stamps.js
@@ -11,7 +11,8 @@ function generateStamps(uiDefinition, stampsDefition) {
   var prevBtnIdx = findButtonIndex(INSERT_STAMP_AFTER, uiDefinition.buttons);
   uiDefinition.buttons.splice(prevBtnIdx + 1, 0, {
     name: 'stamp',
-    tooltip: 'Stamp tool (click and hold to show available categories)',
+    tooltip: 'Stamp tool (click and hold, or press the right arrow key, to show categories)',
+    ariaLabel: 'Stamp tool',
     classes: 'dt-expand dt-img-btn',
     label: 'M',
     palette: 'main',

--- a/app/scripts/ui/line-width-button.js
+++ b/app/scripts/ui/line-width-button.js
@@ -7,12 +7,9 @@ function LineWidthButton(options, ui, drawingTool, extraClasses) {
     this.dt.setStrokeWidth(options.width);
     this.dt.setSelectionStrokeWidth(options.width);
   };
+  options.isToggle = true;
   options.onStateChange = function (state) {
-    if (state.strokeWidth === options.width) {
-      this.$element.addClass('dt-active');
-    } else {
-      this.$element.removeClass('dt-active');
-    }
+    this.setActive(state.strokeWidth === options.width);
   };
   BasicButton.call(this, options, ui, drawingTool, extraClasses);
 }

--- a/app/scripts/ui/palette.js
+++ b/app/scripts/ui/palette.js
@@ -38,21 +38,23 @@ function Palette(options, ui) {
   // browser may not have focused the new element yet, so check
   // relatedTarget rather than document.activeElement.
   this._onFocusOut = function (e) {
-    // Palettes that stay open on click (hideOnClick: false) are also kept
-    // open on focusout. They anchor child palettes (stamp categories ->
-    // category stamps); a child palette is a sibling div, not nested here,
-    // so moving focus into it would otherwise auto-hide this parent and
-    // break the child's focus restoration to an anchor that is now hidden.
-    // These palettes are closed with Escape (see _onKeyDown) instead.
-    if (!this.hideOnClick) {
-      return;
-    }
     var newTarget = e.relatedTarget;
+    // Focus is staying inside this palette: keep it open.
     if (newTarget && (this.$element.is(newTarget) || this.$element.find(newTarget).length > 0)) {
       return;
     }
+    // Focus is moving into a child palette - one opened from a button
+    // inside this palette (stamp categories -> a category's stamps). The
+    // child is a sibling <div>, not nested here, so keep this parent open
+    // so the child can later restore focus to its anchor button.
+    if (newTarget && this._focusMovedToChildPalette(newTarget)) {
+      return;
+    }
+    // Focus has genuinely left (Tab-away, or focus moved elsewhere). Close,
+    // but do NOT restore focus to the anchor: that would steal focus from
+    // wherever the user is heading and trap them back in the toolbar.
     if (this.$element.is(':visible')) {
-      this._hide();
+      this._hide(false);
     }
   }.bind(this);
 
@@ -135,10 +137,17 @@ Palette.prototype._show = function () {
   }.bind(this), 16);
 };
 
-Palette.prototype._hide = function () {
-  // If keyboard focus is inside the palette when it closes, return it to
-  // the anchor button so the user isn't dropped back to the document body.
-  var hadFocus = this.$element.find(document.activeElement).length > 0;
+Palette.prototype._hide = function (restoreFocus) {
+  if (restoreFocus === undefined) {
+    restoreFocus = true;
+  }
+  // When closing, return focus to the anchor only if focus is currently
+  // inside the palette, so the user isn't dropped back to the document
+  // body. A focusout-driven close passes restoreFocus=false: during a
+  // focusout document.activeElement is unreliable and the user is already
+  // moving elsewhere, so restoring focus would steal it from the element
+  // they are tabbing to (a keyboard trap).
+  var hadFocus = restoreFocus && this.$element.find(document.activeElement).length > 0;
   this.$element.hide();
   this._clearWindowHandlers();
   var anchorButton = this.anchor && this.ui.getButton(this.anchor);
@@ -150,6 +159,20 @@ Palette.prototype._hide = function () {
       anchorButton.$element.trigger('focus');
     }
   }
+};
+
+// True when `target` lives inside a palette that was opened from a button
+// within this palette (e.g. a stamp category's stamps, opened from a
+// category button inside the stamp-categories palette). Anchor buttons
+// reference the palette they open via aria-controls, so the anchor of the
+// palette containing `target` being inside this palette marks it as a child.
+Palette.prototype._focusMovedToChildPalette = function (target) {
+  var $palette = $(target).closest('.dt-palette');
+  if (!$palette.length) {
+    return false;
+  }
+  var $anchor = $('[aria-controls="' + $palette.attr('id') + '"]');
+  return $anchor.length > 0 && this.$element.find($anchor).length > 0;
 };
 
 Palette.prototype._clearWindowHandlers = function () {

--- a/app/scripts/ui/palette.js
+++ b/app/scripts/ui/palette.js
@@ -1,14 +1,24 @@
 var $ = require('jquery');
 
+// Palette ids must be unique across the whole page (they are referenced by
+// aria-controls) and one page may host several drawing tool instances.
+var _paletteIdx = 0;
+
 function Palette(options, ui) {
   this.ui          = ui;
   this.name        = options.name;
   this.permanent   = !!options.permanent;
   this.hideOnClick = options.hideOnClick === undefined ? true : options.hideOnClick;
   this.anchor      = options.anchor;
+  this.id          = 'dt-palette-' + _paletteIdx++;
   this.$element    = $('<div>')
+    .attr('id', this.id)
     .addClass('dt-palette')
     .addClass(options.vertical ? 'dt-vertical' : 'dt-horizontal');
+
+  if (options.label) {
+    this.$element.attr('role', 'group').attr('aria-label', options.label);
+  }
 
   this.topOffset = options.hasOwnProperty('topOffset') ? options.topOffset : 0;
   this.leftOffset = options.hasOwnProperty('leftOffset') ? options.leftOffset : 0;
@@ -43,6 +53,7 @@ Palette.prototype._show = function () {
   var anchorButton = this.anchor && this.ui.getButton(this.anchor);
   if (anchorButton) {
     anchorButton.$element.addClass("dt-active");
+    anchorButton.$element.attr('aria-expanded', 'true');
   }
 
   if (this.permanent) {
@@ -65,6 +76,7 @@ Palette.prototype._hide = function () {
   var anchorButton = this.anchor && this.ui.getButton(this.anchor);
   if (anchorButton) {
     anchorButton.$element.removeClass("dt-active");
+    anchorButton.$element.attr('aria-expanded', 'false');
     if (hadFocus) {
       anchorButton.$element.trigger('focus');
     }

--- a/app/scripts/ui/palette.js
+++ b/app/scripts/ui/palette.js
@@ -38,6 +38,15 @@ function Palette(options, ui) {
   // browser may not have focused the new element yet, so check
   // relatedTarget rather than document.activeElement.
   this._onFocusOut = function (e) {
+    // Palettes that stay open on click (hideOnClick: false) are also kept
+    // open on focusout. They anchor child palettes (stamp categories ->
+    // category stamps); a child palette is a sibling div, not nested here,
+    // so moving focus into it would otherwise auto-hide this parent and
+    // break the child's focus restoration to an anchor that is now hidden.
+    // These palettes are closed with Escape (see _onKeyDown) instead.
+    if (!this.hideOnClick) {
+      return;
+    }
     var newTarget = e.relatedTarget;
     if (newTarget && (this.$element.is(newTarget) || this.$element.find(newTarget).length > 0)) {
       return;

--- a/app/scripts/ui/palette.js
+++ b/app/scripts/ui/palette.js
@@ -57,13 +57,18 @@ Palette.prototype._show = function () {
 };
 
 Palette.prototype._hide = function () {
+  // If keyboard focus is inside the palette when it closes, return it to
+  // the anchor button so the user isn't dropped back to the document body.
+  var hadFocus = this.$element.find(document.activeElement).length > 0;
   this.$element.hide();
   this._clearWindowHandlers();
   var anchorButton = this.anchor && this.ui.getButton(this.anchor);
   if (anchorButton) {
     anchorButton.$element.removeClass("dt-active");
+    if (hadFocus) {
+      anchorButton.$element.trigger('focus');
+    }
   }
-
 };
 
 Palette.prototype._clearWindowHandlers = function () {

--- a/app/scripts/ui/palette.js
+++ b/app/scripts/ui/palette.js
@@ -33,8 +33,55 @@ function Palette(options, ui) {
     this._clearWindowHandlers();
   }.bind(this);
 
+  // Close the palette when keyboard focus moves out of it. Mirrors the
+  // mousedown auto-hide for mouse users. During a focusout event the
+  // browser may not have focused the new element yet, so check
+  // relatedTarget rather than document.activeElement.
+  this._onFocusOut = function (e) {
+    var newTarget = e.relatedTarget;
+    if (newTarget && (this.$element.is(newTarget) || this.$element.find(newTarget).length > 0)) {
+      return;
+    }
+    if (this.$element.is(':visible')) {
+      this._hide();
+    }
+  }.bind(this);
+
+  // Keyboard handling inside an open palette. Palette options are not
+  // individual Tab stops (they are tabindex="-1", set in
+  // UIManager._setupKeyboardNavigation), so Arrow / Home / End are the only
+  // way to move between them. Escape closes the palette; _hide returns
+  // focus to the anchor button.
+  this._onKeyDown = function (e) {
+    if (e.keyCode === 27 /* Escape */) {
+      e.stopPropagation();
+      this._hide();
+      return;
+    }
+    var $btns = this.$element.find('.dt-btn');
+    if (!$btns.length) {
+      return;
+    }
+    var idx = $btns.index(document.activeElement);
+    var target = null;
+    switch (e.keyCode) {
+      case 37: /* ArrowLeft  */
+      case 38: /* ArrowUp    */ target = idx - 1; break;
+      case 39: /* ArrowRight */
+      case 40: /* ArrowDown  */ target = idx + 1; break;
+      case 36: /* Home       */ target = 0; break;
+      case 35: /* End        */ target = $btns.length - 1; break;
+      default: return;
+    }
+    e.preventDefault();
+    var n = $btns.length;
+    $btns.eq((target % n + n) % n).trigger('focus');  // wraps both ends
+  }.bind(this);
+
   if (!this.permanent) {
     this.$element.hide();
+    this.$element.on('focusout', this._onFocusOut);
+    this.$element.on('keydown', this._onKeyDown);
   }
 }
 
@@ -44,6 +91,15 @@ Palette.prototype.toggle = function () {
   } else {
     this._show();
   }
+};
+
+// Opens the palette (if needed) and moves keyboard focus to its first
+// button. Used for keyboard-driven opening, where focus must land inside.
+Palette.prototype.showAndFocus = function () {
+  if (!this.$element.is(':visible')) {
+    this._show();
+  }
+  this.$element.find('.dt-btn').first().trigger('focus');
 };
 
 Palette.prototype._show = function () {

--- a/app/scripts/ui/palette.js
+++ b/app/scripts/ui/palette.js
@@ -117,7 +117,10 @@ Palette.prototype._show = function () {
 
   var anchorButton = this.anchor && this.ui.getButton(this.anchor);
   if (anchorButton) {
-    anchorButton.$element.addClass("dt-active");
+    // The "palette is open" highlight is driven by aria-expanded in CSS,
+    // not dt-active. dt-active means "this tool/value is selected" and is
+    // owned by setActive(); reusing it here let _hide() wipe a still-valid
+    // selection highlight when a palette closed after picking a tool.
     anchorButton.$element.attr('aria-expanded', 'true');
   }
 
@@ -140,7 +143,8 @@ Palette.prototype._hide = function () {
   this._clearWindowHandlers();
   var anchorButton = this.anchor && this.ui.getButton(this.anchor);
   if (anchorButton) {
-    anchorButton.$element.removeClass("dt-active");
+    // Only clear the expanded state - dt-active (selected tool/value) is
+    // owned by setActive() and must survive the palette closing.
     anchorButton.$element.attr('aria-expanded', 'false');
     if (hadFocus) {
       anchorButton.$element.trigger('focus');

--- a/app/scripts/ui/selected-line-width-button.js
+++ b/app/scripts/ui/selected-line-width-button.js
@@ -5,7 +5,7 @@ var BasicButton = require('./basic-button');
 function SelectedLineWidthButton(options, ui, drawingTool, extraClasses) {
   BasicButton.call(this, options, ui, drawingTool, extraClasses);
 
-  this.$width = $('<div>')
+  this.$width = $('<span>')
     .addClass('dt-selected-line-width')
     .html(8)
     .appendTo(this.$element);

--- a/app/scripts/ui/selected-line-width-button.js
+++ b/app/scripts/ui/selected-line-width-button.js
@@ -7,6 +7,10 @@ function SelectedLineWidthButton(options, ui, drawingTool, extraClasses) {
 
   this.$width = $('<span>')
     .addClass('dt-selected-line-width')
+    // Decorative state indicator: the button's aria-label already names it
+    // ("Stroke width"), so hide this number from the a11y tree to avoid a
+    // visible-label / accessible-name mismatch (WCAG 2.5.3).
+    .attr('aria-hidden', 'true')
     .html(8)
     .appendTo(this.$element);
 }

--- a/app/scripts/ui/stamp-image-button.js
+++ b/app/scripts/ui/stamp-image-button.js
@@ -11,6 +11,13 @@ function StampImageButton(options, ui, drawingTool, extraClasses) {
   this._stamp = null;
   this._imageSrc = drawingTool.proxy(options.imageSrc);
 
+  // Stamps are configured as bare image URLs; derive an accessible name
+  // from the file name, e.g. ".../stamps/simple-atom.svg" => "simple atom stamp".
+  var fileName = (options.imageSrc || '').split('/').pop().split('.')[0];
+  if (fileName) {
+    this.$element.attr('aria-label', decodeURIComponent(fileName).replace(/[-_]+/g, ' ') + ' stamp');
+  }
+
   this.$element.addClass('dt-img-btn');
 
   this._startWaiting();

--- a/app/scripts/ui/stamp-image-button.js
+++ b/app/scripts/ui/stamp-image-button.js
@@ -16,7 +16,16 @@ function StampImageButton(options, ui, drawingTool, extraClasses) {
   // from the file name, e.g. ".../stamps/simple-atom.svg" => "simple atom stamp".
   var fileName = (options.imageSrc || '').split('/').pop().split('.')[0];
   if (fileName) {
-    this.$element.attr('aria-label', decodeURIComponent(fileName).replace(/[-_]+/g, ' ') + ' stamp');
+    // Stamps come from arbitrary configured URLs; a stray '%' that isn't
+    // valid percent-encoding makes decodeURIComponent throw, which would
+    // crash toolbar init. Fall back to the raw file name in that case.
+    var label;
+    try {
+      label = decodeURIComponent(fileName);
+    } catch (e) {
+      label = fileName;
+    }
+    this.$element.attr('aria-label', label.replace(/[-_]+/g, ' ') + ' stamp');
   }
 
   this.$element.addClass('dt-img-btn');

--- a/app/scripts/ui/stamp-image-button.js
+++ b/app/scripts/ui/stamp-image-button.js
@@ -6,6 +6,7 @@ function StampImageButton(options, ui, drawingTool, extraClasses) {
   options.onClick = function () {
     this.dt.setStampObject(this._stamp, this._imageSrc);
   };
+  options.isToggle = true;
   BasicButton.call(this, options, ui, drawingTool, extraClasses);
 
   this._stamp = null;

--- a/app/scripts/ui/stamp-image-button.js
+++ b/app/scripts/ui/stamp-image-button.js
@@ -16,7 +16,7 @@ function StampImageButton(options, ui, drawingTool, extraClasses) {
   this._startWaiting();
   this.dt.tools.stamp.loadImage(this._imageSrc, function (fabricObj, img) {
     this._stamp = fabricObj;
-    this.$image = $(img).appendTo(this.$element);
+    this.$image = $(img).attr('alt', '').appendTo(this.$element);
     this._stopWaiting();
   }.bind(this), null, 'anonymous');
 

--- a/app/scripts/ui/ui-definition.js
+++ b/app/scripts/ui/ui-definition.js
@@ -65,27 +65,33 @@ var ui = {
     },
     {
       name: 'lines',
-      anchor: 'linesPalette'
+      anchor: 'linesPalette',
+      label: 'Line types'
     },
     {
       name: 'shapes',
-      anchor: 'shapesPalette'
+      anchor: 'shapesPalette',
+      label: 'Shapes'
     },
     {
       name: 'fontSizes',
-      anchor: 'text'
+      anchor: 'text',
+      label: 'Font sizes'
     },
     {
       name: 'strokeColors',
-      anchor: 'strokeColorPalette'
+      anchor: 'strokeColorPalette',
+      label: 'Stroke colors'
     },
     {
       name: 'fillColors',
-      anchor: 'fillColorPalette'
+      anchor: 'fillColorPalette',
+      label: 'Fill colors'
     },
     {
       name: 'strokeWidths',
-      anchor: 'strokeWidthPalette'
+      anchor: 'strokeWidthPalette',
+      label: 'Stroke widths'
     }
   ],
   buttons: [

--- a/app/scripts/ui/ui-definition.js
+++ b/app/scripts/ui/ui-definition.js
@@ -4,17 +4,22 @@ var ColorButton     = require('./color-button');
 var LineWidthButton = require('./line-width-button');
 var SelectedLineWidthButton = require('./selected-line-width-button');
 
+// Keyboard shortcut hints shown in tooltips. The shortcuts themselves are
+// implemented in undo-redo.js, clone-tool.js, delete-tool.js, select-tool.js.
+var isMac = typeof navigator !== 'undefined' && /Mac|iPad|iPhone/.test(navigator.platform);
+var modKey = isMac ? 'Cmd+' : 'Ctrl+';
+
 var COLORS = [
-  {value: '',        icon: require('../../assets/color-none-icon.svg')},
-  {value: '#3f3f3f', icon: require('../../assets/color-black-icon.svg')},
-  {value: '#fff',    icon: require('../../assets/color-white-icon.svg')},
-  {value: '#bfbfbf', icon: require('../../assets/color-gray-icon.svg')},
-  {value: '#eb0000', icon: require('../../assets/color-red-icon.svg')},
-  {value: '#008a00', icon: require('../../assets/color-green-icon.svg')},
-  {value: '#00f',    icon: require('../../assets/color-blue-icon.svg')},
-  {value: '#ff8415', icon: require('../../assets/color-orange-icon.svg')},
-  {value: '#ff0',    icon: require('../../assets/color-yellow-icon.svg')},
-  {value: '#d100d1', icon: require('../../assets/color-purple-icon.svg')},
+  {value: '',        name: 'No color', icon: require('../../assets/color-none-icon.svg')},
+  {value: '#3f3f3f', name: 'Black',    icon: require('../../assets/color-black-icon.svg')},
+  {value: '#fff',    name: 'White',    icon: require('../../assets/color-white-icon.svg')},
+  {value: '#bfbfbf', name: 'Gray',     icon: require('../../assets/color-gray-icon.svg')},
+  {value: '#eb0000', name: 'Red',      icon: require('../../assets/color-red-icon.svg')},
+  {value: '#008a00', name: 'Green',    icon: require('../../assets/color-green-icon.svg')},
+  {value: '#00f',    name: 'Blue',     icon: require('../../assets/color-blue-icon.svg')},
+  {value: '#ff8415', name: 'Orange',   icon: require('../../assets/color-orange-icon.svg')},
+  {value: '#ff0',    name: 'Yellow',   icon: require('../../assets/color-yellow-icon.svg')},
+  {value: '#d100d1', name: 'Purple',   icon: require('../../assets/color-purple-icon.svg')},
  ];
 
 var STROKE_WIDTHS = [
@@ -105,7 +110,8 @@ var ui = {
     },
     {
       name: 'linesPalette',
-      tooltip: 'Line tool (click and hold to show available line types)',
+      tooltip: 'Line tool (click and hold, or press the right arrow key, to show line types)',
+      ariaLabel: 'Line tool',
       classes: 'dt-expand',
       reflectsTools: ['line', 'arrow', 'doubleArrow'],
       palette: 'main',
@@ -122,7 +128,8 @@ var ui = {
     },
     {
       name: 'shapesPalette',
-      tooltip: 'Basic shape tool (click and hold to show available shapes)',
+      tooltip: 'Basic shape tool (click and hold, or press the right arrow key, to show shapes)',
+      ariaLabel: 'Basic shape tool',
       classes: 'dt-expand',
       reflectsTools: ['rect', 'ellipse', 'square', 'circle'],
       palette: 'main',
@@ -139,7 +146,8 @@ var ui = {
     },
     {
       name: 'text',
-      tooltip: 'Text tool (click and hold to show available font sizes)',
+      tooltip: 'Text tool (click and hold, or press the right arrow key, to show font sizes)',
+      ariaLabel: 'Text tool',
       label: 'T',
       // Do not exit text edit mode on click. See text tool class.
       classes: 'dt-expand dt-keep-text-edit-mode',
@@ -157,7 +165,8 @@ var ui = {
     },
     {
       name: 'strokeColorPalette',
-      tooltip: 'Stroke color (click and hold to show available colors)',
+      tooltip: 'Stroke color (opens color palette)',
+      ariaLabel: 'Stroke color',
       buttonClass: StrokeButton,
       // Do not exit text edit mode on click. See text tool class.
       classes: 'dt-keep-text-edit-mode',
@@ -175,7 +184,8 @@ var ui = {
     },
     {
       name: 'fillColorPalette',
-      tooltip: 'Fill color (click and hold to show available colors)',
+      tooltip: 'Fill color (opens color palette)',
+      ariaLabel: 'Fill color',
       buttonClass: FillButton,
       palette: 'main',
       onInit: function () {
@@ -191,7 +201,8 @@ var ui = {
     },
     {
       name: 'strokeWidthPalette',
-      tooltip: 'Stroke width (click and hold to show available options)',
+      tooltip: 'Stroke width (opens width palette)',
+      ariaLabel: 'Stroke width',
       buttonClass: SelectedLineWidthButton,
       label: 'w',
       palette: 'main',
@@ -205,7 +216,8 @@ var ui = {
     },
     {
       name: 'clone',
-      tooltip: 'Clone tool',
+      tooltip: 'Clone tool (' + modKey + 'C to copy, ' + modKey + 'V to paste selection)',
+      ariaLabel: 'Clone tool',
       label: 'c',
       activatesTool: 'clone',
       palette: 'main',
@@ -238,7 +250,8 @@ var ui = {
     },
     {
       name: 'undo',
-      tooltip: 'Undo',
+      tooltip: 'Undo (' + modKey + 'Z)',
+      ariaLabel: 'Undo',
       label: 'u',
       classes: 'dt-undo-redo',
       palette: 'main',
@@ -258,7 +271,8 @@ var ui = {
     },
     {
       name: 'redo',
-      tooltip: 'Redo',
+      tooltip: 'Redo (' + modKey + 'Y)',
+      ariaLabel: 'Redo',
       label: 'r',
       classes: 'dt-undo-redo',
       palette: 'main',
@@ -278,7 +292,8 @@ var ui = {
     },
     {
       name: 'trash',
-      tooltip: 'Delete selected objects',
+      tooltip: 'Delete selected objects (Delete or Backspace key)',
+      ariaLabel: 'Delete selected objects',
       label: 'd',
       activatesTool: 'trash',
       palette: 'main',
@@ -366,6 +381,7 @@ FONT_SIZES.forEach(function (fontSize) {
   ui.buttons.push({
     label: 'T',
     tooltip: fontSize + 'px',
+    ariaLabel: fontSize + ' pixel font',
     // Do not exit text edit mode on click. See text tool class.
     classes: 'dt-keep-text-edit-mode',
     onClick: function () {
@@ -383,7 +399,7 @@ FONT_SIZES.forEach(function (fontSize) {
 COLORS.forEach(function (color) {
   ui.buttons.push({
     buttonClass: ColorButton,
-    tooltip: color.value,
+    tooltip: color.name + ' stroke color',
     // Do not exit text edit mode on click. See text tool class.
     classes: 'dt-keep-text-edit-mode',
     color: color.value,
@@ -393,7 +409,7 @@ COLORS.forEach(function (color) {
   });
   ui.buttons.push({
     buttonClass: ColorButton,
-    tooltip: color.value,
+    tooltip: color.name + ' fill color',
     color: color.value,
     type: 'fill',
     palette: 'fillColors',
@@ -405,6 +421,7 @@ STROKE_WIDTHS.forEach(function (width) {
   ui.buttons.push({
     buttonClass: LineWidthButton,
     tooltip: width.value + 'px',
+    ariaLabel: width.value + ' pixel stroke width',
     width: width.value,
     palette: 'strokeWidths',
     icon: width.icon

--- a/app/scripts/ui/ui-definition.js
+++ b/app/scripts/ui/ui-definition.js
@@ -382,6 +382,7 @@ FONT_SIZES.forEach(function (fontSize) {
     label: 'T',
     tooltip: fontSize + 'px',
     ariaLabel: fontSize + ' pixel font',
+    isToggle: true,
     // Do not exit text edit mode on click. See text tool class.
     classes: 'dt-keep-text-edit-mode',
     onClick: function () {

--- a/app/scripts/ui/ui-manager.js
+++ b/app/scripts/ui/ui-manager.js
@@ -123,6 +123,18 @@ UIManager.prototype.togglePalette = function (name) {
   this._palettes[name].toggle();
 };
 
+// Hide every open popup palette (permanent palettes - the main toolbar -
+// stay put). _hide only restores focus when focus was inside the palette,
+// so calling this while focus is on a main button does not steal it.
+UIManager.prototype._closeOpenPalettes = function () {
+  for (var name in this._palettes) {
+    var palette = this._palettes[name];
+    if (!palette.permanent && palette.$element.is(':visible')) {
+      palette._hide();
+    }
+  }
+};
+
 UIManager.prototype.getMainContainer = function () {
   return this.drawingTool.$element;
 };
@@ -219,7 +231,14 @@ UIManager.prototype._setupKeyboardNavigation = function () {
   // The one button that IS the toolbar's tab stop.
   $main.eq(0).attr('tabindex', '0');
 
+  var self = this;
   function focusAt(i) {
+    // Roving to another main button means we are leaving any open popup
+    // palette behind. Mouse/long-press opening leaves focus on the main
+    // anchor (focus never enters the palette), so without this an Arrow
+    // key would rove away while the palette stayed open - letting several
+    // palettes be visible at once. Close them as we move.
+    self._closeOpenPalettes();
     var n = $main.length;
     var idx = (i % n + n) % n;  // wrap around both ends
     $main.attr('tabindex', '-1');

--- a/app/scripts/ui/ui-manager.js
+++ b/app/scripts/ui/ui-manager.js
@@ -88,6 +88,8 @@ function UIManager(drawingTool) {
   for (var paletteName in this._palettes) {
     this._setupPaletteAnchor(this._palettes[paletteName]);
   }
+
+  this._setupKeyboardNavigation();
 }
 
 UIManager.prototype._processUIDefinition = function (uiDef) {
@@ -166,7 +168,8 @@ UIManager.prototype._setupPaletteActiveButton = function (button) {
 };
 
 // Expose the relation between an expandable button and the palette it
-// opens to assistive technology.
+// opens to assistive technology, and let keyboard users open it
+// (mouse/touch users use click-and-hold or click).
 UIManager.prototype._setupPaletteAnchor = function (palette) {
   var anchorButton = palette.anchor && this.getButton(palette.anchor);
   if (!anchorButton) {
@@ -176,6 +179,70 @@ UIManager.prototype._setupPaletteAnchor = function (palette) {
     .attr('aria-haspopup', 'true')
     .attr('aria-controls', palette.id)
     .attr('aria-expanded', 'false');
+  anchorButton.$element.on('keydown', function (e) {
+    // ArrowRight opens the palette (palettes fly out to the right of their
+    // anchor). ArrowUp/ArrowDown are reserved for moving between toolbar
+    // buttons (roving tabindex), so they must NOT open the palette.
+    if (e.keyCode === 39 /* ArrowRight */) {
+      e.preventDefault();
+      palette.showAndFocus();
+      return;
+    }
+    // The button's own Enter/Space handler runs first (bound earlier). If
+    // it just opened this palette (stroke color, fill color, stroke width
+    // toggle their palette on click), move focus into it.
+    if ((e.keyCode === 13 /* Enter */ || e.keyCode === 32 /* Space */) &&
+        palette.$element.is(':visible')) {
+      palette.showAndFocus();
+    }
+  });
+};
+
+// Make the toolbar a single Tab stop with a roving tabindex (ARIA Toolbar
+// pattern). Only one main-toolbar button is in the page tab order at a
+// time; Arrow / Home / End keys move focus AND the tab stop between
+// buttons. Popup-palette buttons are never their own Tab stop - they are
+// reached by opening their palette (ArrowRight / Enter on the anchor).
+UIManager.prototype._setupKeyboardNavigation = function () {
+  // Every toolbar/palette button: programmatically focusable, but not a
+  // Tab stop.
+  this.$tools.find('.dt-btn').attr('tabindex', '-1');
+
+  var mainPalette = this.getPalette('main');
+  if (!mainPalette) {
+    return;
+  }
+  var $main = mainPalette.$element.find('.dt-btn');
+  if (!$main.length) {
+    return;
+  }
+  // The one button that IS the toolbar's tab stop.
+  $main.eq(0).attr('tabindex', '0');
+
+  function focusAt(i) {
+    var n = $main.length;
+    var idx = (i % n + n) % n;  // wrap around both ends
+    $main.attr('tabindex', '-1');
+    $main.eq(idx).attr('tabindex', '0').trigger('focus');
+  }
+
+  $main.on('keydown', function (e) {
+    var idx = $main.index(this);
+    switch (e.keyCode) {
+      case 38: /* ArrowUp   */ e.preventDefault(); focusAt(idx - 1); break;
+      case 40: /* ArrowDown */ e.preventDefault(); focusAt(idx + 1); break;
+      case 36: /* Home      */ e.preventDefault(); focusAt(0); break;
+      case 35: /* End       */ e.preventDefault(); focusAt($main.length - 1); break;
+    }
+  });
+
+  // When a main button receives focus by any route (mouse click, or focus
+  // returning from a closed palette), make it the sole tab stop so a later
+  // Shift+Tab / Tab leaves from the right place.
+  $main.on('focus', function () {
+    $main.attr('tabindex', '-1');
+    $(this).attr('tabindex', '0');
+  });
 };
 
 var _idx = 0;

--- a/app/scripts/ui/ui-manager.js
+++ b/app/scripts/ui/ui-manager.js
@@ -7,8 +7,14 @@ var uiDefinition   = require('./ui-definition');
 function UIManager(drawingTool) {
   this.drawingTool = drawingTool;
 
+  // role="toolbar" + roving tabindex (set up in Task 6): the whole toolbar
+  // is one Tab stop and Arrow keys move between buttons. The toolbar is a
+  // vertical column, so aria-orientation is vertical.
   this.$tools = $('<div>')
     .addClass('dt-tools')
+    .attr('role', 'toolbar')
+    .attr('aria-orientation', 'vertical')
+    .attr('aria-label', 'Drawing tools')
     .prependTo(drawingTool.$element);
 
   // Toolbar should be the height of the canvas.
@@ -77,6 +83,10 @@ function UIManager(drawingTool) {
     if (btn.onInit) {
       btn.onInit.call(btn, this, drawingTool);
     }
+  }
+
+  for (var paletteName in this._palettes) {
+    this._setupPaletteAnchor(this._palettes[paletteName]);
   }
 }
 
@@ -153,6 +163,19 @@ UIManager.prototype._setupPaletteActiveButton = function (button) {
     // This will update "active" palette button during every click / touch.
     this._paletteActiveButton[button.palette] = button;
   }.bind(this));
+};
+
+// Expose the relation between an expandable button and the palette it
+// opens to assistive technology.
+UIManager.prototype._setupPaletteAnchor = function (palette) {
+  var anchorButton = palette.anchor && this.getButton(palette.anchor);
+  if (!anchorButton) {
+    return;
+  }
+  anchorButton.$element
+    .attr('aria-haspopup', 'true')
+    .attr('aria-controls', palette.id)
+    .attr('aria-expanded', 'false');
 };
 
 var _idx = 0;

--- a/app/styles/drawing-tool.scss
+++ b/app/styles/drawing-tool.scss
@@ -95,6 +95,14 @@ $text: Arial, sans-serif;
   }
 
   .dt-btn {
+    // .dt-btn elements are native <button>s - reset the user agent styles
+    // so they render exactly like the divs they used to be.
+    appearance: none;
+    -webkit-appearance: none;
+    border: none;
+    margin: 0;
+    font-family: inherit;
+
     z-index: 1000;
     display: block;
     overflow: hidden;
@@ -118,6 +126,13 @@ $text: Arial, sans-serif;
     &:hover {
       background: $cc-teal-light5B;
       cursor: pointer;
+    }
+
+    // Keyboard focus indicator. Inset so it isn't overlapped by adjacent
+    // buttons (the buttons butt up against each other with no gaps).
+    &:focus-visible {
+      outline: 2px solid $cc-teal-dark-2;
+      outline-offset: -2px;
     }
 
     &.dt-active {

--- a/app/styles/drawing-tool.scss
+++ b/app/styles/drawing-tool.scss
@@ -135,7 +135,12 @@ $text: Arial, sans-serif;
       outline-offset: -2px;
     }
 
-    &.dt-active {
+    // dt-active: this tool/value is selected. aria-expanded: this button's
+    // palette is open. Both share the same highlight but are independent
+    // states, so a button can be selected and not open, or open and not
+    // selected, without one clobbering the other.
+    &.dt-active,
+    &[aria-expanded="true"] {
       background: $cc-teal-light-4;
     }
 
@@ -159,7 +164,8 @@ $text: Arial, sans-serif;
       line-height: $buttonSize;
       margin-top: -1px;
 
-      &.dt-active {
+      &.dt-active,
+      &[aria-expanded="true"] {
         border-right: $border-width solid $cc-teal-light-4;
       }
     }


### PR DESCRIPTION
## Summary

Makes the drawing-tool toolbar keyboard operable and ARIA compliant ([QI-155](https://concord-consortium.atlassian.net/browse/QI-155)), without touching dependencies or the build system. Implements the [W3C ARIA Toolbar pattern](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/) with a roving tabindex.

- **Native buttons** — every `.dt-btn` is now a real `<button type="button">` with UA-style reset and a `:focus-visible` ring; icon images are decorative (`alt=""`).
- **Keyboard activation** — Enter/Space activate buttons (routed through the existing `mousedown` path the library relies on); palettes close and return focus to their anchor.
- **Accessible names & shortcuts** — every button has an `aria-label`; tooltips list keyboard shortcuts (Undo `Cmd/Ctrl+Z`, Redo `Cmd/Ctrl+Y`, Clone copy/paste, Delete/Backspace); colors are named instead of raw hex.
- **State exposure** — `aria-pressed` on toggle buttons (tools, colors, widths, fonts, stamps), `aria-expanded`/`aria-controls`/`aria-haspopup` on expandable buttons, `aria-disabled` on locked buttons, group labels + `role="toolbar"` container.
- **Roving-tabindex navigation** — the whole toolbar is one Tab stop; ↑/↓ move between buttons (wrapping), Home/End jump to ends, → opens a palette and moves focus inside, arrow keys navigate within palettes, Esc closes and restores focus.
- Page-unique palette ids so multiple drawing-tool instances on one page stay independent (verified on `two-tools.html`).

Covers all Jira acceptance criteria (native buttons, keyboard reachability, arrow navigation, `aria-label`, `aria-pressed`, `aria-expanded`/`aria-controls`, `alt=""`, shortcut tooltips, and the implied keyboard path to long-press-only palettes + locked-state signalling).

## Test Plan

This repo has no automated test infrastructure (and the task scoped out adding one), so verification was scripted browser checks per task plus a Lighthouse audit. To re-verify go to: https://models-resources.concord.org/drawing-tool/branch/toolbar-accessibility/examples/

- [ ] One Tab enters the toolbar, a second Tab leaves it (single tab stop); ↑/↓/Home/End move focus with a visible ring.
- [ ] Enter/Space activate buttons; Space doesn't scroll. → opens lines/shapes/font/stamp palettes with focus inside; Enter opens color/width palettes; arrows navigate within; Esc closes and restores focus.
- [ ] Inspect the Accessibility tree: buttons report role/name, toggles report pressed, expandable report expanded/collapsed, locked report disabled.
- [ ] Mouse regression: click tools, click-and-hold to open palettes, click to open color/width palettes, outside-click auto-hide.
- [ ] `examples/two-tools.html`: both toolbars work independently; all `aria-controls` ids resolve within their own instance.
- [ ] Lighthouse accessibility audit on the toolbar subtree: no toolbar-attributable violations (remaining `landmark-one-main` is the demo page, not the component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[QI-155]: https://concord-consortium.atlassian.net/browse/QI-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ